### PR TITLE
Implement rate-limited Roam API wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.11.4",
     "@roam-research/roam-api-sdk": "^0.10.0",
-    "dotenv": "^16.4.7"
+    "dotenv": "^16.4.7",
+    "bottleneck": "^2.19.5"
   },
   "devDependencies": {
     "@types/node": "^20.11.24",

--- a/src/search/block-ref-search.ts
+++ b/src/search/block-ref-search.ts
@@ -1,4 +1,4 @@
-import { q } from '@roam-research/roam-api-sdk';
+import { q } from '../utils/roam-api-wrapper.js';
 import type { Graph } from '@roam-research/roam-api-sdk';
 import { BaseSearchHandler, SearchResult } from './types.js';
 import { SearchUtils } from './utils.js';

--- a/src/search/datomic-search.ts
+++ b/src/search/datomic-search.ts
@@ -1,4 +1,4 @@
-import { q } from '@roam-research/roam-api-sdk';
+import { q } from '../utils/roam-api-wrapper.js';
 import type { Graph } from '@roam-research/roam-api-sdk';
 import { BaseSearchHandler, SearchResult } from './types.js';
 // import { resolveRefs } from '../helpers/refs.js';

--- a/src/search/hierarchy-search.ts
+++ b/src/search/hierarchy-search.ts
@@ -1,4 +1,4 @@
-import { q } from '@roam-research/roam-api-sdk';
+import { q } from '../utils/roam-api-wrapper.js';
 import type { Graph } from '@roam-research/roam-api-sdk';
 import { BaseSearchHandler, SearchResult } from './types.js';
 import { SearchUtils } from './utils.js';

--- a/src/search/indented-hierarchy-search.ts
+++ b/src/search/indented-hierarchy-search.ts
@@ -1,4 +1,4 @@
-import { q } from '@roam-research/roam-api-sdk';
+import { q } from '../utils/roam-api-wrapper.js';
 import type { Graph } from '@roam-research/roam-api-sdk';
 import { BaseSearchHandler, SearchResult } from './types.js';
 import { SearchUtils } from './utils.js';

--- a/src/search/status-search.ts
+++ b/src/search/status-search.ts
@@ -1,4 +1,4 @@
-import { q } from '@roam-research/roam-api-sdk';
+import { q } from '../utils/roam-api-wrapper.js';
 import type { Graph } from '@roam-research/roam-api-sdk';
 import { BaseSearchHandler, SearchResult } from './types.js';
 import { SearchUtils } from './utils.js';

--- a/src/search/tag-search.ts
+++ b/src/search/tag-search.ts
@@ -1,4 +1,4 @@
-import { q } from '@roam-research/roam-api-sdk';
+import { q } from '../utils/roam-api-wrapper.js';
 import type { Graph } from '@roam-research/roam-api-sdk';
 import { BaseSearchHandler, TagSearchParams, SearchResult } from './types.js';
 import { SearchUtils } from './utils.js';

--- a/src/search/text-search.ts
+++ b/src/search/text-search.ts
@@ -1,4 +1,4 @@
-import { q } from '@roam-research/roam-api-sdk';
+import { q } from '../utils/roam-api-wrapper.js';
 import type { Graph } from '@roam-research/roam-api-sdk';
 import { BaseSearchHandler, SearchResult } from './types.js';
 import { SearchUtils } from './utils.js';

--- a/src/search/utils.ts
+++ b/src/search/utils.ts
@@ -1,5 +1,5 @@
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
-import { q } from '@roam-research/roam-api-sdk';
+import { q } from '../utils/roam-api-wrapper.js';
 import type { Graph } from '@roam-research/roam-api-sdk';
 import type { SearchResult } from './types.js';
 

--- a/src/utils/rate-limiter.ts
+++ b/src/utils/rate-limiter.ts
@@ -1,0 +1,14 @@
+import Bottleneck from 'bottleneck';
+
+export const globalLimiter = new Bottleneck({
+  reservoir: 300,
+  reservoirRefreshAmount: 300,
+  reservoirRefreshInterval: 60 * 1000,
+  maxConcurrent: 1
+});
+
+export function createToolLimiter(options: Bottleneck.ConstructorOptions = {}): Bottleneck {
+  const limiter = new Bottleneck(options);
+  limiter.chain(globalLimiter);
+  return limiter;
+}

--- a/src/utils/roam-api-wrapper.ts
+++ b/src/utils/roam-api-wrapper.ts
@@ -1,0 +1,35 @@
+import type { Graph, BatchAction } from '@roam-research/roam-api-sdk';
+import {
+  q as apiQ,
+  createPage as apiCreatePage,
+  createBlock as apiCreateBlock,
+  updateBlock as apiUpdateBlock,
+  batchActions as apiBatchActions
+} from '@roam-research/roam-api-sdk';
+import type Bottleneck from 'bottleneck';
+import { globalLimiter } from './rate-limiter.js';
+
+function schedule<T>(limiter: Bottleneck | null, fn: () => Promise<T>): Promise<T> {
+  const l = limiter ?? globalLimiter;
+  return l.schedule(fn);
+}
+
+export function q(graph: Graph, query: string, params: unknown[], limiter?: Bottleneck) {
+  return schedule(limiter ?? null, () => apiQ(graph, query, params));
+}
+
+export function createPage(graph: Graph, params: any, limiter?: Bottleneck) {
+  return schedule(limiter ?? null, () => apiCreatePage(graph, params));
+}
+
+export function createBlock(graph: Graph, params: any, limiter?: Bottleneck) {
+  return schedule(limiter ?? null, () => apiCreateBlock(graph, params));
+}
+
+export function updateBlock(graph: Graph, params: any, limiter?: Bottleneck) {
+  return schedule(limiter ?? null, () => apiUpdateBlock(graph, params));
+}
+
+export function batchActions(graph: Graph, params: { action: 'batch-actions'; actions: BatchAction[] }, limiter?: Bottleneck) {
+  return schedule(limiter ?? null, () => apiBatchActions(graph, params));
+}


### PR DESCRIPTION
## Summary
- add Bottleneck-based rate limiter
- wrap Roam API calls so everything goes through the limiter
- use per-tool limiters in the various operations
- depend on `bottleneck` library

## Testing
- `npm run build` *(fails: Cannot find module 'dotenv' and others)*